### PR TITLE
Cleaned up the Installer a bit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
         "php":                              ">=7.0",
         "composer-plugin-api":              "^1.0.0",
         "hostnet/path-composer-plugin-lib": "^1.0.2",
-        "squizlabs/php_codesniffer":        "^3.2.0"
+        "squizlabs/php_codesniffer":        "^3.2.0",
+        "symfony/filesystem":               "^4.0"
     },
     "require-dev": {
         "composer/composer": "^1.5.5",
@@ -23,6 +24,9 @@
             "Hostnet": "test/"
         }
     },
+    "scripts": {
+        "post-autoload-dump": "Hostnet\\Component\\CodeSniffer\\Installer::configureAsRoot"
+    },
     "config": {
         "bin-dir": "bin",
         "preferred-install": {
@@ -31,9 +35,6 @@
     },
     "extra": {
         "class": "Hostnet\\Component\\CodeSniffer\\Installer"
-    },
-    "scripts": {
-        "post-autoload-dump": "Hostnet\\Component\\CodeSniffer\\Installer::configureAsRoot"
     },
     "archive": {
         "exclude": [

--- a/src/Hostnet/Component/CodeSniffer/Installer.php
+++ b/src/Hostnet/Component/CodeSniffer/Installer.php
@@ -33,6 +33,9 @@ class Installer implements PluginInterface, EventSubscriberInterface
         return [ScriptEvents::POST_AUTOLOAD_DUMP => 'execute'];
     }
 
+    /**
+     * Configuration for standalone use in a system wide installation scenario
+     */
     public static function configureAsRoot()
     {
         $filesystem = new Filesystem();


### PR DESCRIPTION
- Use the `symfony/filesystem` package for filesystem related calls (this improves error handling)
- Ensured that `Configured phpcs to use Hostnet standard` is outputted after configuring the tool
- Changed a few calls to have early exists
- Added some return typehints
- Replaced PHPDoc where possible with `{@inheritdoc}`