### PR TITLE
FIX: Do show warnings

### DIFF
--- a/src/Hostnet/Sniffs/Commenting/AtCoversCounterPartSniff.php
+++ b/src/Hostnet/Sniffs/Commenting/AtCoversCounterPartSniff.php
@@ -48,13 +48,13 @@ class AtCoversCounterPartSniff extends FileCommentSniff
             return count($tokens) + 1;
         }
 
-        $fix           = <<<FIX
+        $fix          = <<<FIX
 /**
  * @covers $expected_covers_namespace
  */
 FIX;
-        $fix          .= PHP_EOL;
-        $fix_position  = $start_of_class;
+        $fix         .= PHP_EOL;
+        $fix_position = $start_of_class;
         // The class doc should be within +/- 5 tokens of the class token.
         if ($end_of_header_doc !== false && $end_of_header_doc > ($start_of_class - 5)) {
             $fix          = sprintf("* @covers %s\n ", $expected_covers_namespace);

--- a/src/Hostnet/ruleset.xml
+++ b/src/Hostnet/ruleset.xml
@@ -5,8 +5,8 @@
     <arg name="extensions" value="php"/>
     <arg name="colors"/>
 
-    <!-- Ignore warnings, show progress of the run and show sniff names -->
-    <arg value="ns"/>
+    <!-- Show sniff names -->
+    <arg value="s"/>
 
     <!-- Import PSR-2 coding standard (base) -->
     <rule ref="PSR2"/>


### PR DESCRIPTION
Apparently PHPCBF does not fix warnings if you ignore them.