### PR TITLE
FIX: Revert MultipleStatementAlignment to old defintion

### DIFF
--- a/src/Hostnet/ruleset.xml
+++ b/src/Hostnet/ruleset.xml
@@ -29,7 +29,12 @@
     <rule ref="Generic.PHP.ForbiddenFunctions"/>
     <rule ref="Generic.PHP.NoSilencedErrors"/>
 
-    <rule ref="Generic.Formatting.MultipleStatementAlignment"/>
+    <rule ref="Generic.Formatting.MultipleStatementAlignment">
+        <properties>
+            <property name="ignoreMultiLine" value="true"/>
+            <property name="error" value="true"/>
+        </properties>
+    </rule>
 
     <rule ref="Generic.Files.LineLength">
         <properties>


### PR DESCRIPTION
It used to throw errors in 5.3.0, except during the 6.0.0 upgrade I've removed the wrong definition (there were two) and thus it changed to a warning. 

We expected it to throw errors in all the new versions so this should be released a patch and not a major.