### PR TITLE
Fix squizlabs/php_codesniffer at 3.2.0 for now

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "composer-plugin-api":              "^1.0.0",
         "hostnet/path-composer-plugin-lib": "^1.0.2",
         "slevomat/coding-standard":         "^4.6.0",
-        "squizlabs/php_codesniffer":        "^3.2.0",
+        "squizlabs/php_codesniffer":        "~3.2.0",
         "symfony/filesystem":               "^3.0.2|^4.0"
     },
     "require-dev": {


### PR DESCRIPTION
The latest version of `squizlabs/php_codesniffer` (3.3.0) introduces issues that we have to deal with first, before we can upgrade. PHPCS does not follow SemVer so this is the way to go.