### PR TITLE
Remove EarlyExit rule - has unintended side effects

### DIFF
--- a/src/Hostnet/ruleset.xml
+++ b/src/Hostnet/ruleset.xml
@@ -130,9 +130,6 @@
     <!-- report invalid format of inline phpDocs with @var -->
     <rule ref="SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration"/>
 
-    <!-- Require usage of early exit -->
-    <rule ref="SlevomatCodingStandard.ControlStructures.EarlyExit"/>
-
     <!-- Require language constructs without parentheses -->
     <rule ref="SlevomatCodingStandard.ControlStructures.LanguageConstructWithParentheses"/>
 


### PR DESCRIPTION
While I agree with the intent of the sniff, early exits are a good idea, it is not always a good idea.

I saw some diffs where the code was becoming unreadable because this sniff inverts if statements, hence my proposal to remove it.