### PR TITLE
use "present" as copyright righthandside year

### DIFF
--- a/test/Hostnet/Tests/Commenting/FileCommentCopyrightUnitTest.1.inc.fixed
+++ b/test/Hostnet/Tests/Commenting/FileCommentCopyrightUnitTest.1.inc.fixed
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright 2017-2018 Hostnet B.V.
+ * @copyright 2017-present Hostnet B.V.
  */
 /**
  * Test1234

--- a/test/Hostnet/Tests/Commenting/FileCommentCopyrightUnitTest.10.inc.fixed
+++ b/test/Hostnet/Tests/Commenting/FileCommentCopyrightUnitTest.10.inc.fixed
@@ -1,7 +1,7 @@
 <?php
 /**
  * Gekkie
- * @copyright 2017-2018 Hostnet B.V.
+ * @copyright 2017-present Hostnet B.V.
  */
 /**
  * Class doc

--- a/test/Hostnet/Tests/Commenting/FileCommentCopyrightUnitTest.11.inc
+++ b/test/Hostnet/Tests/Commenting/FileCommentCopyrightUnitTest.11.inc
@@ -1,0 +1,11 @@
+<?php
+/**
+ * @copyright 2018-present Hostnet B.V.
+ */
+
+/**
+ * Class abc
+ */
+class abc {
+
+}

--- a/test/Hostnet/Tests/Commenting/FileCommentCopyrightUnitTest.12.inc
+++ b/test/Hostnet/Tests/Commenting/FileCommentCopyrightUnitTest.12.inc
@@ -1,0 +1,11 @@
+<?php
+/**
+ * @copyright 2018-2019 Hostnet B.V.
+ */
+
+/**
+ * Class abc
+ */
+class abc {
+
+}

--- a/test/Hostnet/Tests/Commenting/FileCommentCopyrightUnitTest.2.inc.fixed
+++ b/test/Hostnet/Tests/Commenting/FileCommentCopyrightUnitTest.2.inc.fixed
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright 2017-2018 Hostnet B.V.
+ * @copyright 2017-present Hostnet B.V.
  */
 
 /**

--- a/test/Hostnet/Tests/Commenting/FileCommentCopyrightUnitTest.3.inc.fixed
+++ b/test/Hostnet/Tests/Commenting/FileCommentCopyrightUnitTest.3.inc.fixed
@@ -2,7 +2,7 @@
 /**
  *
  *
- * @copyright 2017-2018 Hostnet B.V.
+ * @copyright 2017-present Hostnet B.V.
  */
 
 /**

--- a/test/Hostnet/Tests/Commenting/FileCommentCopyrightUnitTest.4.inc.fixed
+++ b/test/Hostnet/Tests/Commenting/FileCommentCopyrightUnitTest.4.inc.fixed
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright 2017-2018 Hostnet B.V.
+ * @copyright 2017-present Hostnet B.V.
  */
 
 /**

--- a/test/Hostnet/Tests/Commenting/FileCommentCopyrightUnitTest.5.inc.fixed
+++ b/test/Hostnet/Tests/Commenting/FileCommentCopyrightUnitTest.5.inc.fixed
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright 2017-2018 Hostnet B.V.
+ * @copyright 2017-present Hostnet B.V.
  */
 
 class abc {

--- a/test/Hostnet/Tests/Commenting/FileCommentCopyrightUnitTest.6.inc.fixed
+++ b/test/Hostnet/Tests/Commenting/FileCommentCopyrightUnitTest.6.inc.fixed
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright 2017-2018 Hostnet B.V.
+ * @copyright 2017-present Hostnet B.V.
  */
 /**
  * @copyright 2077 Some one

--- a/test/Hostnet/Tests/Commenting/FileCommentCopyrightUnitTest.8.inc.fixed
+++ b/test/Hostnet/Tests/Commenting/FileCommentCopyrightUnitTest.8.inc.fixed
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright 2017-2018 Hostnet B.V.
+ * @copyright 2017-present Hostnet B.V.
  */
 /**
  * A nice class


### PR DESCRIPTION
Following the symfony example we change the most recent year in our copyright messages to "present" to prevent useless updates to all our files every year. the sniff will *NOT* "fix" the current years because this causes mayhem in code reviews. To change all the copyright notices use the following bash command: 
```bash
find -type f -name '*.php'  | xargs sed -i 's/@copyright \([0-9]\+\)\(-[0-9]\+\)\? Hostnet B.V.$/@copyright \1-present Hostnet B.V./'
``` 