### PR TITLE
Add ClassConstantVisibilitySniff to HostnetExperimental

### DIFF
--- a/src/HostnetExperimental/ruleset.xml
+++ b/src/HostnetExperimental/ruleset.xml
@@ -2,6 +2,7 @@
 <ruleset name="HostnetExperimental">
     <description>The future Hostnet coding standard.</description>
     <rule ref="Hostnet"/>
+    <rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility"/>
     <rule ref="SlevomatCodingStandard.TypeHints.TypeHintDeclaration">
         <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint"/>
         <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingPropertyTypeHint"/>


### PR DESCRIPTION
Adds the ClassConstantVisibilitySniff to HostnetExperimental.
It does not have a fixer, forcing you to think about the visibility.