### PR TITLE
Hotfix: rtrim with a charlist removes more than 'Test'.

### DIFF
--- a/src/Hostnet/Sniffs/Commenting/AtCoversCounterPartSniff.php
+++ b/src/Hostnet/Sniffs/Commenting/AtCoversCounterPartSniff.php
@@ -34,7 +34,7 @@ class AtCoversCounterPartSniff extends FileCommentSniff
 
         $test_namespace            = $this->getNamespaceFromFile($phpcs_file->getFilename());
         $counter_part_namespace    = str_replace('Tests\\', '', $test_namespace);
-        $counter_part_namespace    = substr($counter_part_namespace, 0, strrpos($counter_part_namespace, 'Test'));
+        $counter_part_namespace    = \substr($counter_part_namespace, 0, \strrpos($counter_part_namespace, 'Test'));
         $expected_covers_namespace = "\\$counter_part_namespace";
         if (!\class_exists($counter_part_namespace) || \in_array($expected_covers_namespace, $namespaces, true)) {
             return count($tokens) + 1;

--- a/src/Hostnet/Sniffs/Commenting/AtCoversCounterPartSniff.php
+++ b/src/Hostnet/Sniffs/Commenting/AtCoversCounterPartSniff.php
@@ -34,7 +34,7 @@ class AtCoversCounterPartSniff extends FileCommentSniff
 
         $test_namespace            = $this->getNamespaceFromFile($phpcs_file->getFilename());
         $counter_part_namespace    = str_replace('Tests\\', '', $test_namespace);
-        $counter_part_namespace    = rtrim($counter_part_namespace, 'Test');
+        $counter_part_namespace    = substr($counter_part_namespace, 0, strrpos($counter_part_namespace, 'Test'));
         $expected_covers_namespace = "\\$counter_part_namespace";
         if (!\class_exists($counter_part_namespace) || \in_array($expected_covers_namespace, $namespaces, true)) {
             return count($tokens) + 1;


### PR DESCRIPTION
Example: **MyClassTest** resolved to **MyCla** before, because **s** was part of the rtrim charlist.
This problem only occurred if there actually was an existing class with the name **MyCla**.

I have not included a test case, because for some odd reason \class_exists returns false on my newly created test classes in the test directory.