### PR TITLE
Return exit code 0 on warnings.

### DIFF
--- a/src/Hostnet/Component/CodeSniffer/Installer.php
+++ b/src/Hostnet/Component/CodeSniffer/Installer.php
@@ -92,8 +92,9 @@ class Installer implements PluginInterface, EventSubscriberInterface
     {
         $filesystem = new Filesystem();
         $config     = [
-            'colors'          => '1',
-            'installed_paths' => implode(',', [
+            'colors'                  => '1',
+            'ignore_warnings_on_exit' => '1',
+            'installed_paths'         => implode(',', [
                 Path::VENDOR_DIR . '/hostnet/phpcs-tool/src/',
                 Path::VENDOR_DIR . '/slevomat/coding-standard/SlevomatCodingStandard',
                 Path::VENDOR_DIR . '/mediawiki/mediawiki-codesniffer/MediaWiki',


### PR DESCRIPTION
Warnings currently result in an exit code 1, but it would be nice if they would result in an exit code 0. 
To improve daily work scripts e.g. `phpcs || yesno -y "Ignore?"`.