### PR TITLE
Added the Slevomat parameter type hint spacing rule

### DIFF
--- a/src/Hostnet/ruleset.xml
+++ b/src/Hostnet/ruleset.xml
@@ -187,6 +187,8 @@
         </properties>
     </rule>
 
+    <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing"/>
+
     <!-- Require use of short versions of scalar types (i.e. int instead of integer) -->
     <rule ref="SlevomatCodingStandard.TypeHints.LongTypeHints"/>
 

--- a/src/Hostnet/ruleset.xml
+++ b/src/Hostnet/ruleset.xml
@@ -197,6 +197,9 @@
         </properties>
     </rule>
 
+    <!-- Require exactly one space between typehint and variable, or zero with the nullability symbol -->
+    <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacingSniff"/>
+
     <!-- Require space around colon in return types -->
     <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing"/>
 

--- a/src/Hostnet/ruleset.xml
+++ b/src/Hostnet/ruleset.xml
@@ -197,9 +197,6 @@
         </properties>
     </rule>
 
-    <!-- Require exactly one space between typehint and variable, or zero with the nullability symbol -->
-    <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacingSniff"/>
-
     <!-- Require space around colon in return types -->
     <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing"/>
 

--- a/src/HostnetExperimental/ruleset.xml
+++ b/src/HostnetExperimental/ruleset.xml
@@ -17,7 +17,4 @@
         <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingTraversableReturnTypeHintSpecification"/>
         <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.UselessDocComment"/>
     </rule>
-
-    <!-- Require exactly one space between typehint and variable, or zero with the nullability symbol -->
-    <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing"/>
 </ruleset>

--- a/src/HostnetExperimental/ruleset.xml
+++ b/src/HostnetExperimental/ruleset.xml
@@ -17,4 +17,7 @@
         <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingTraversableReturnTypeHintSpecification"/>
         <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.UselessDocComment"/>
     </rule>
+
+    <!-- Require exactly one space between typehint and variable, or zero with the nullability symbol -->
+    <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing"/>
 </ruleset>


### PR DESCRIPTION
Good
```
    public function doSomething(
        string $parameter_one,
        VeryLongClassName $parameter_two
    ): void {
```
```
    public function doSomething(?string $parameter): void {
```

Bad
```
    public function doSomething(
        string            $parameter_one,
        VeryLongClassName $parameter_two
    ): void {
```
```
    public function doSomething(? string $parameter): void {
```
```
    public function doSomething(?string  $parameter): void {
```

Reasoning:
- The Slevomat standard
- PHPStorm reformat code standard