### PR TITLE
Remove SlevomatCodingStandard.Namespaces.UnusedUses sniff

### DIFF
--- a/src/Hostnet/ruleset.xml
+++ b/src/Hostnet/ruleset.xml
@@ -318,9 +318,4 @@
         </properties>
     </rule>
     <rule ref="MediaWiki.WhiteSpace.MultipleEmptyLines"/>
-    <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses">
-        <properties>
-            <property name="searchAnnotations" value="true"/>
-        </properties>
-    </rule>
 </ruleset>


### PR DESCRIPTION
Removes SlevomatCodingStandard.Namespaces.UnusedUses sniff.
The sniff also removes use statements from files which need it for traits they use, but don't need the use statement themselves. This may break existing code, or cause it to silently fail if the included trait uses instanceof checks for example.