### PR TITLE
Upgrade en re-add UnusedUses sniff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-    - 7.1
     - 7.2
     - 7.3
     - nightly

--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,8 @@
         "php":                              ">=7.1",
         "composer-plugin-api":              "^1.0.0",
         "hostnet/path-composer-plugin-lib": "^1.0.2",
-        "mediawiki/mediawiki-codesniffer":  "^26.0.0",
-        "slevomat/coding-standard":         "^4.6.0",
+        "mediawiki/mediawiki-codesniffer":  "^28.0.0",
+        "slevomat/coding-standard":         "^5.0.4",
         "squizlabs/php_codesniffer":        "^3.4.2",
         "symfony/filesystem":               "^3.0.2|^4.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "PHP_CodeSniffer tokenises PHP, JavaScript and CSS files and detects violations of a defined set of coding standards. Hostnet version",
     "license":     "MIT",
     "require": {
-        "php":                              ">=7.1",
+        "php":                              ">=7.2",
         "composer-plugin-api":              "^1.0.0",
         "hostnet/path-composer-plugin-lib": "^1.0.2",
         "mediawiki/mediawiki-codesniffer":  "^28.0.0",

--- a/src/Hostnet/ruleset.xml
+++ b/src/Hostnet/ruleset.xml
@@ -203,7 +203,7 @@
     <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing"/>
 
     <!-- Forbid empty lines around type declarations -->
-    <rule ref="SlevomatCodingStandard.Types.EmptyLinesAroundTypeBraces">
+    <rule ref="SlevomatCodingStandard.Classes.EmptyLinesAroundClassBraces">
         <properties>
             <property name="linesCountAfterOpeningBrace" value="0"/>
             <property name="linesCountBeforeClosingBrace" value="0"/>

--- a/src/HostnetExperimental/ruleset.xml
+++ b/src/HostnetExperimental/ruleset.xml
@@ -4,6 +4,12 @@
     <rule ref="Hostnet"/>
     <rule ref="Squiz.Strings.DoubleQuoteUsage.NotRequired" />
     <rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility"/>
+    <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses">
+        <exclude phpcbf-only="true" name="SlevomatCodingStandard.Namespaces.UnusedUses.UnusedUse"/>
+        <properties>
+            <property name="searchAnnotations" value="true"/>
+        </properties>
+    </rule>
     <rule ref="SlevomatCodingStandard.TypeHints.TypeHintDeclaration">
         <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint"/>
         <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingPropertyTypeHint"/>


### PR DESCRIPTION
- Upgrades mediawiki-codesniffer and slevomat/coding-standard
- Re-adds UnusedUses sniff to HostnetExperimental (autofixer disabled). Disabled the autofixer until https://github.com/doctrine/annotations/issues/81 is fixed.