### PR TITLE
Allow catch statements with only comments.

### DIFF
--- a/src/Hostnet/ruleset.xml
+++ b/src/Hostnet/ruleset.xml
@@ -51,6 +51,14 @@
     <!-- Forbid empty statements -->
     <rule ref="Generic.CodeAnalysis.EmptyStatement"/>
 
+    <!-- Allow empty catch statements -->
+    <rule ref="Generic.CodeAnalysis.EmptyStatement.DetectedCatch">
+        <severity>0</severity>
+    </rule>
+
+    <!-- Allow a catch statement with only comments -->
+    <rule ref="Squiz.Commenting.EmptyCatchComment"/>
+
     <!-- Forbid final methods in final classes -->
     <rule ref="Generic.CodeAnalysis.UnnecessaryFinalModifier"/>
 

--- a/src/Hostnet/ruleset.xml
+++ b/src/Hostnet/ruleset.xml
@@ -51,12 +51,10 @@
     <!-- Forbid empty statements -->
     <rule ref="Generic.CodeAnalysis.EmptyStatement"/>
 
-    <!-- Allow empty catch statements -->
+    <!-- Allow a catch statement with only comments -->
     <rule ref="Generic.CodeAnalysis.EmptyStatement.DetectedCatch">
         <severity>0</severity>
     </rule>
-
-    <!-- Allow a catch statement with only comments -->
     <rule ref="Squiz.Commenting.EmptyCatchComment"/>
 
     <!-- Forbid final methods in final classes -->


### PR DESCRIPTION
Code example
```php
    try {
        echo 'test'; // Line #125
    } catch (\Exception $e) {
    }
    
    try {
        echo 'test'; // Line #129
    } catch (\Exception $e) {
    
    }
    
    try {
        echo 'test'; // Line #135
    } catch (\Exception $e) {
        // test
    }
    
    try {
        echo 'test';
    } catch (\Exception $e) {
        echo 'test';
    }
```

Before
```
------------------------------------------------------------------
FOUND 3 ERRORS AFFECTING 3 LINES
-------------------------------------------------------------------------------------------------
 125 | ERROR | Empty CATCH statement detected (Generic.CodeAnalysis.EmptyStatement.DetectedCatch)
 130 | ERROR | Empty CATCH statement detected (Generic.CodeAnalysis.EmptyStatement.DetectedCatch)
 136 | ERROR | Empty CATCH statement detected (Generic.CodeAnalysis.EmptyStatement.DetectedCatch)
-------------------------------------------------------------------------------------------------
```

After
```
----------------------------------------------------------------------------------------------------
FOUND 2 ERRORS AFFECTING 2 LINES
----------------------------------------------------------------------------------------------------
 125 | ERROR | Empty CATCH statement must have a comment to explain why the exception is not handled
     |       | (Squiz.Commenting.EmptyCatchComment.Missing)
 130 | ERROR | Empty CATCH statement must have a comment to explain why the exception is not handled
     |       | (Squiz.Commenting.EmptyCatchComment.Missing)
----------------------------------------------------------------------------------------------------
```