### PR TITLE
Add UselessInheritDocComment to HostnetExperimental

### DIFF
--- a/src/Hostnet/Component/CodeSniffer/Installer.php
+++ b/src/Hostnet/Component/CodeSniffer/Installer.php
@@ -60,9 +60,6 @@ class Installer implements PluginInterface, EventSubscriberInterface
         );
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function activate(Composer $composer, IOInterface $io): void
     {
         $this->io = $io;

--- a/src/HostnetExperimental/ruleset.xml
+++ b/src/HostnetExperimental/ruleset.xml
@@ -18,4 +18,5 @@
         <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingTraversableReturnTypeHintSpecification"/>
         <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.UselessDocComment"/>
     </rule>
+    <rule ref="SlevomatCodingStandard.Commenting.UselessInheritDocComment"/>
 </ruleset>


### PR DESCRIPTION
- Add UselessInheritDocComment to HostnetExperimental; will be moved to the Hostnet ruleset when we don't run into issues with other code-style checks.