### PR TITLE
Updates to be compatible with Composer 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,15 +5,14 @@
     "license":     "MIT",
     "require": {
         "php":                              ">=7.2",
-        "composer-plugin-api":              "^1.0.0",
-        "hostnet/path-composer-plugin-lib": "^1.0.2",
-        "mediawiki/mediawiki-codesniffer":  "^28.0.0",
+        "composer-plugin-api":              "^2.0.0",
+        "hostnet/path-composer-plugin-lib": "^1.0.4",
+        "mediawiki/mediawiki-codesniffer":  "^31.0.0",
         "slevomat/coding-standard":         "^5.0.4",
         "squizlabs/php_codesniffer":        "^3.4.2",
         "symfony/filesystem":               "^4.0||^5.0"
     },
     "require-dev": {
-        "composer/composer": "^1.5.5",
         "phpunit/phpunit":   "^6.5.4"
     },
     "autoload": {

--- a/src/Hostnet/Component/CodeSniffer/Installer.php
+++ b/src/Hostnet/Component/CodeSniffer/Installer.php
@@ -65,6 +65,14 @@ class Installer implements PluginInterface, EventSubscriberInterface
         $this->io = $io;
     }
 
+    public function deactivate(Composer $composer, IOInterface $io)
+    {
+    }
+
+    public function uninstall(Composer $composer, IOInterface $io)
+    {
+    }
+
     /**
      * The 'logical'-operation of this Installer.
      * PHPCS does not define constants for the config options,


### PR DESCRIPTION
Fixes `Fatal error: Class Hostnet\Component\CodeSniffer\Installer contains 2 abstract methods and must therefore be declared abstract or implement the remaining methods (Composer\Plugin\PluginInterface::deactivate, Composer\Plugin\PluginInterface::uninstall)` in both phpcs-tool and path-composer-plugin-lib.

Also removed unnecessary composer in require-dev, which conflicts on composer/semver.