### PR TITLE
Copy only MediaWiki sniff and do not require mediawiki-codesniffer anymore

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,12 +7,12 @@
         "php":                              ">=7.2",
         "composer-plugin-api":              "^2.0.0",
         "hostnet/path-composer-plugin-lib": "^1.0.4",
-        "mediawiki/mediawiki-codesniffer":  "^31.0.0",
         "slevomat/coding-standard":         "^5.0.4",
         "squizlabs/php_codesniffer":        "^3.4.2",
         "symfony/filesystem":               "^4.0||^5.0"
     },
     "require-dev": {
+        "composer/composer": "^2.0.2",
         "phpunit/phpunit":   "^6.5.4"
     },
     "autoload": {

--- a/src/Hostnet/Component/CodeSniffer/Installer.php
+++ b/src/Hostnet/Component/CodeSniffer/Installer.php
@@ -102,7 +102,6 @@ class Installer implements PluginInterface, EventSubscriberInterface
             'installed_paths'         => implode(',', [
                 Path::VENDOR_DIR . '/hostnet/phpcs-tool/src/',
                 Path::VENDOR_DIR . '/slevomat/coding-standard/SlevomatCodingStandard',
-                Path::VENDOR_DIR . '/mediawiki/mediawiki-codesniffer/MediaWiki',
             ]),
         ];
 

--- a/src/Hostnet/Sniffs/Classes/MultipleEmptyLinesSniff.php
+++ b/src/Hostnet/Sniffs/Classes/MultipleEmptyLinesSniff.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Check multiple consecutive newlines in a file.
+ * Copied from MediaWiki coding conventions.
+ */
+
+namespace Hostnet\Sniffs\Classes;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+class MultipleEmptyLinesSniff implements Sniff {
+
+	/**
+	 * @inheritDoc
+	 */
+	public function register() {
+		return [
+			// Assume most comments end with a newline
+			T_COMMENT,
+			// Assume all <?php open tags end with a newline
+			T_OPEN_TAG,
+			T_WHITESPACE,
+		];
+	}
+
+	/**
+	 * @param File $phpcsFile
+	 * @param int $stackPtr The current token index.
+	 * @return void|int
+	 */
+	public function process( File $phpcsFile, $stackPtr ) {
+		$tokens = $phpcsFile->getTokens();
+
+		// This sniff intentionally doesn't care about whitespace at the end of the file
+		if ( !isset( $tokens[$stackPtr + 3] ) ||
+			$tokens[$stackPtr + 2]['line'] === $tokens[$stackPtr + 3]['line']
+		) {
+			return $stackPtr + 3;
+		}
+
+		if ( $tokens[$stackPtr + 1]['line'] === $tokens[$stackPtr + 2]['line'] ) {
+			return $stackPtr + 2;
+		}
+
+		// Finally, check the assumption the current token is or ends with a newline
+		if ( $tokens[$stackPtr]['line'] === $tokens[$stackPtr + 1]['line'] ) {
+			return;
+		}
+
+		// Search for the next non-newline token
+		$next = $stackPtr + 1;
+		while ( isset( $tokens[$next + 1] ) &&
+			$tokens[$next]['code'] === T_WHITESPACE &&
+			$tokens[$next]['line'] !== $tokens[$next + 1]['line']
+		) {
+			$next++;
+		}
+		$count = $next - $stackPtr - 1;
+
+		if ( $count > 1 &&
+			$phpcsFile->addFixableError(
+				'Multiple empty lines should not exist in a row; found %s consecutive empty lines',
+				$stackPtr + 1,
+				'MultipleEmptyLines',
+				[ $count ]
+			)
+		) {
+			$phpcsFile->fixer->beginChangeset();
+			// Remove all newlines except the first two, i.e. keep one empty line
+			for ( $i = $stackPtr + 2; $i < $next; $i++ ) {
+				$phpcsFile->fixer->replaceToken( $i, '' );
+			}
+			$phpcsFile->fixer->endChangeset();
+		}
+
+		// Don't check the current sequence a second time
+		return $next;
+	}
+}

--- a/src/Hostnet/ruleset.xml
+++ b/src/Hostnet/ruleset.xml
@@ -323,5 +323,4 @@
             <property name="ignoreBlankLines" value="false"/>
         </properties>
     </rule>
-    <rule ref="MediaWiki.WhiteSpace.MultipleEmptyLines"/>
 </ruleset>


### PR DESCRIPTION
Only copy MultipleEmptyLinesSniff.php to our sources as mediawiki-codesniffer is incompatible.