### PR TITLE
Update slevomat/coding-standard for php8 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php":                              ">=7.2",
         "composer-plugin-api":              "^2.0.0",
         "hostnet/path-composer-plugin-lib": "^1.0.4",
-        "slevomat/coding-standard":         "^5.0.4",
+        "slevomat/coding-standard":         "^7.0.9",
         "squizlabs/php_codesniffer":        "^3.4.2",
         "symfony/filesystem":               "^4.0||^5.0"
     },

--- a/src/Hostnet/ruleset.xml
+++ b/src/Hostnet/ruleset.xml
@@ -165,6 +165,7 @@
 
     <!-- Require presence of declare(strict_types=1) -->
     <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
+        <exclude name="SlevomatCodingStandard.TypeHints.DeclareStrictTypes.IncorrectWhitespaceBeforeDeclare"/>
         <properties>
             <property name="newlinesCountBetweenOpenTagAndDeclare" value="1"/>
             <property name="spacesCountAroundEqualsSign" value="0"/>


### PR DESCRIPTION
- Updates slevomat/coding-standard for php8 compatibility

Hopefully fixes https://github.com/hostnet/accessor-generator-plugin-lib/pull/59/checks?check_run_id=2949896757