### PR TITLE
Move rules to Level-1 and beyond for compatibility

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <ruleset name="Hostnet PHPCodeSniffer Standard">
-  <rule ref="Hostnet"/>
+  <rule ref="HostnetExperimental"/>
   <!-- Copied from mediawiki-codesniffer -->
   <exclude-pattern>src/Hostnet/Sniffs/Classes/MultipleEmptyLinesSniff.php</exclude-pattern>
   <!-- Copied from squizlabs/php_codesniffer -->

--- a/src/Hostnet-Level-1/ruleset.xml
+++ b/src/Hostnet-Level-1/ruleset.xml
@@ -3,7 +3,6 @@
     <description>Hostnet coding standard, supplemented with rules for useless code.</description>
     <rule ref="Hostnet"/>
     <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses">
-        <exclude phpcbf-only="true" name="SlevomatCodingStandard.Namespaces.UnusedUses.UnusedUse"/>
         <properties>
             <property name="searchAnnotations" value="true"/>
         </properties>

--- a/src/Hostnet-Level-1/ruleset.xml
+++ b/src/Hostnet-Level-1/ruleset.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<ruleset name="Hostnet-Level-1">
+    <description>Hostnet coding standard, supplemented with rules for useless code.</description>
+    <rule ref="Hostnet"/>
+    <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses">
+        <exclude phpcbf-only="true" name="SlevomatCodingStandard.Namespaces.UnusedUses.UnusedUse"/>
+        <properties>
+            <property name="searchAnnotations" value="true"/>
+        </properties>
+    </rule>
+    <rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility"/>
+    <rule ref="SlevomatCodingStandard.Commenting.UselessInheritDocComment"/>
+</ruleset>

--- a/src/Hostnet-Level-2/ruleset.xml
+++ b/src/Hostnet-Level-2/ruleset.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<ruleset name="Hostnet-Level-2">
+    <description>Hostnet coding standard, supplemented with possibly breaking changes.</description>
+    <rule ref="Hostnet-Level-1"/>
+    <rule ref="SlevomatCodingStandard.TypeHints">
+        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingTraversableTypeHintSpecification"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.DisallowArrayTypeHintSyntax.DisallowedArrayTypeHintSyntax"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue.NullabilityTypeMissing"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint.DisallowedMixedTypeHint"/>
+    </rule>
+</ruleset>

--- a/src/Hostnet/Component/CodeSniffer/Installer.php
+++ b/src/Hostnet/Component/CodeSniffer/Installer.php
@@ -46,18 +46,22 @@ class Installer implements PluginInterface, EventSubscriberInterface
 
         self::configure();
 
-        $filesystem->mkdir($vendor_dir . '/Hostnet');
+        foreach ([
+                'Hostnet',
+                'HostnetPaths',
+                'Hostnet-Level-1',
+                'Hostnet-Level-2',
+                'HostnetExperimental',
+            ] as $ruleset
+        ) {
+            $filesystem->mkdir($vendor_dir . '/' . $ruleset);
+            $filesystem->copy(
+                __DIR__ . '/../../../' . $ruleset . '/ruleset.xml',
+                $vendor_dir . '/' . $ruleset . '/ruleset.xml'
+            );
+        }
+
         $filesystem->symlink(__DIR__ . '/../../Sniffs', $vendor_dir . '/Hostnet/Sniffs');
-        $filesystem->copy(__DIR__ . '/../../ruleset.xml', $vendor_dir . '/Hostnet/ruleset.xml');
-
-        $filesystem->mkdir($vendor_dir . '/HostnetPaths');
-        $filesystem->copy(__DIR__ . '/../../../HostnetPaths/ruleset.xml', $vendor_dir . '/HostnetPaths/ruleset.xml');
-
-        $filesystem->mkdir($vendor_dir . '/HostnetExperimental');
-        $filesystem->copy(
-            __DIR__ . '/../../../HostnetExperimental/ruleset.xml',
-            $vendor_dir . '/HostnetExperimental/ruleset.xml'
-        );
     }
 
     public function activate(Composer $composer, IOInterface $io): void

--- a/src/Hostnet/Sniffs/Commenting/AtCoversCounterPartSniff.php
+++ b/src/Hostnet/Sniffs/Commenting/AtCoversCounterPartSniff.php
@@ -40,12 +40,7 @@ class AtCoversCounterPartSniff extends FileCommentSniff
             return count($tokens) + 1;
         }
 
-        $fix          = <<<FIX
-/**
- * @covers $expected_covers_namespace
- */
-FIX;
-        $fix         .= PHP_EOL;
+        $fix          = sprintf("/**\n * @covers %s\n */\n", $expected_covers_namespace);
         $fix_position = $start_of_class;
         // The class doc should be within +/- 5 tokens of the class token.
         if ($end_of_header_doc !== false && $end_of_header_doc > ($start_of_class - 5)) {

--- a/src/Hostnet/ruleset.xml
+++ b/src/Hostnet/ruleset.xml
@@ -201,27 +201,6 @@
     <!-- Require use of short versions of scalar types (i.e. int instead of integer) -->
     <rule ref="SlevomatCodingStandard.TypeHints.LongTypeHints"/>
 
-    <rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility"/>
-
-    <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses">
-        <exclude phpcbf-only="true" name="SlevomatCodingStandard.Namespaces.UnusedUses.UnusedUse"/>
-        <properties>
-            <property name="searchAnnotations" value="true"/>
-        </properties>
-    </rule>
-
-    <rule ref="SlevomatCodingStandard.TypeHints">
-        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint"/>
-        <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint"/>
-        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingTraversableTypeHintSpecification"/>
-        <exclude name="SlevomatCodingStandard.TypeHints.DisallowArrayTypeHintSyntax.DisallowedArrayTypeHintSyntax"/>
-        <exclude name="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue.NullabilityTypeMissing"/>
-        <exclude name="SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint.DisallowedMixedTypeHint"/>
-        <exclude name="SlevomatCodingStandard.Commenting.UselessFunctionDocComment"/>
-    </rule>
-
-    <rule ref="SlevomatCodingStandard.Commenting.UselessInheritDocComment"/>
-
     <!-- Require one space between typehint and variable, require no space between nullability sign and typehint -->
     <rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing">
         <properties>

--- a/src/HostnetExperimental/ruleset.xml
+++ b/src/HostnetExperimental/ruleset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
 <ruleset name="HostnetExperimental">
     <description>The future Hostnet coding standard.</description>
-    <rule ref="Hostnet"/>
+    <rule ref="Hostnet-Level-2"/>
 </ruleset>


### PR DESCRIPTION
- add compatibility with slevomat/coding-standard:^7.0.19
- partly reverts https://github.com/hostnet/phpcs-tool/commit/36bc5bf42f47b5a1fb58bb50cec48fdc780e7c05 by moving rules out of the Hostnet ruleset again.
- enables fixer for SlevomatCodingStandard.Namespaces.UnusedUses