### PR TITLE
Upgrade slevomat/coding-standard to ^8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php":                              "^7.3|^8.0",
         "composer-plugin-api":              "^2.0.0",
         "hostnet/path-composer-plugin-lib": "^1.0.5",
-        "slevomat/coding-standard":         "^7.0.18",
+        "slevomat/coding-standard":         "^8.6.2",
         "squizlabs/php_codesniffer":        "^3.6.2",
         "symfony/filesystem":               "^4.0||^5.0"
     },


### PR DESCRIPTION
- Upgrades slevomat/coding-standard to ^8
- BC breaks on https://github.com/slevomat/coding-standard/releases/tag/8.0.0 don't relevant