### PR TITLE
Removal of several rules.

### DIFF
--- a/src/Hostnet/ruleset.xml
+++ b/src/Hostnet/ruleset.xml
@@ -30,7 +30,6 @@
 
     <rule ref="Generic.Formatting.MultipleStatementAlignment">
         <properties>
-            <property name="ignoreMultiLine" value="true"/>
             <property name="error" value="true"/>
         </properties>
     </rule>
@@ -169,9 +168,7 @@
     <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
         <exclude name="SlevomatCodingStandard.TypeHints.DeclareStrictTypes.IncorrectWhitespaceBeforeDeclare"/>
         <properties>
-            <property name="newlinesCountBetweenOpenTagAndDeclare" value="1"/>
             <property name="spacesCountAroundEqualsSign" value="0"/>
-            <property name="newlinesCountAfterDeclare" value="2"/>
         </properties>
     </rule>
 


### PR DESCRIPTION
The following rules have been removed by their managing repositories:
```
- Generic.Formatting.MultipleStatementAlignment
    * ignoreMultiLine
- SlevomatCodingStandard.TypeHints.DeclareStrictTypes
    * newlinesCountBetweenOpenTagAndDeclare
    * newlinesCountAfterDeclare
```

This is now an issue because of https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/CHANGELOG.md?plain=1#L77, which results in the following errors:
```
ERROR: Ruleset invalid. Property "ignoreMultiLine" does not exist on sniff Generic.Formatting.MultipleStatementAlignment

ERROR: Ruleset invalid. Property "newlinesCountBetweenOpenTagAndDeclare" does not exist on sniff SlevomatCodingStandard.TypeHints.DeclareStrictTypes

ERROR: Ruleset invalid. Property "newlinesCountAfterDeclare" does not exist on sniff SlevomatCodingStandard.TypeHints.DeclareStrictTypes
```

The references to the removal of these rules in their managing repositories:
https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/CHANGELOG.md?plain=1#L3475
https://github.com/slevomat/coding-standard/commit/b71f8d788e81021be0bb8a7327aced7f952e2f87
https://github.com/slevomat/coding-standard/commit/a623909758b32973190cc582834ab84288adf121
